### PR TITLE
Specify test network during bip32 derivation

### DIFF
--- a/test_framework/revault_network.py
+++ b/test_framework/revault_network.py
@@ -97,7 +97,7 @@ class RevaultNetwork:
 
         # TODO: implement CPFP
         cpfp_xpubs = [
-            bip32.BIP32.from_seed(os.urandom(32)).get_master_xpub()
+            bip32.BIP32.from_seed(os.urandom(32), network="test").get_master_xpub()
             for _ in range(len(mans_keychains))
         ]
         stks_xpubs = [stk.get_xpub() for stk in stks_keychains]

--- a/test_framework/utils.py
+++ b/test_framework/utils.py
@@ -66,7 +66,7 @@ class RpcError(ValueError):
 
 class Participant:
     def __init__(self):
-        self.hd = bip32.BIP32.from_seed(os.urandom(32))
+        self.hd = bip32.BIP32.from_seed(os.urandom(32), network="test")
 
 
 class User(Participant):


### PR DESCRIPTION
Next version of Revaultd requires testnet keys
if the network is not mainnet.