### PR TITLE
nit: Make the POSTGRES_PASSWORD, POSTGRES_USER...

### DIFF
--- a/aquarium.py
+++ b/aquarium.py
@@ -127,7 +127,7 @@ def deploy(n_stks, n_mans, n_stkmans, csv, mans_thresh=None):
         logging.error("I need the Postgres environment variable to be set.")
         print("Example:")
         print(
-            f'  POSTGRES_USER="revault_test" POSTGRES_PASS="revault_test" {sys.argv[0]}'
+            f'  POSTGRES_USER="revault" POSTGRES_PASS="revault" {sys.argv[0]}'
         )
         sys.exit(1)
 


### PR DESCRIPTION
...consistent between aquarium example and README.md

The README.md suggested to start the coordinator with user and
password `revault`, while aquarium.py used `revault_test`. This
micro commit makes them consistent