### PR TITLE
fix aliases: Dump gui and hw logs to dev null

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ but the default is higher).
 
 To launch the GUI for one of the participants:
 ```
-stk0gui >/dev/null &
+stk0gui &
 ```
 (redirecting `stdout` here to avoid getting annoyed by the logs)
 
@@ -186,7 +186,7 @@ participants' GUI would be too much, by default Aquarium configures a single dum
 the keys (and you can choose which keys to sign for at runtime). Start the dummy signer with the
 following alias:
 ```
-hw >/dev/null &
+hw &
 ```
 
 We'll directly sign with all the stakeholders' keys. For "The Real Revault Experience" (tm) or
@@ -216,8 +216,8 @@ here depends of course of hypothetical spending policy we could enforce manually
 Now we can start 2 managers (remember, there are 3 managers but the threshold for spending is only
 of 2).
 ```
-$ man0gui >/dev/null &
-$ stkman0gui >/dev/null &
+$ man0gui &
+$ stkman0gui &
 $ bcli getnewaddress
 bcrt1q2zn3znj8v5s2tp9v9pt9jvwxder8sv2ve9yc09
 ```

--- a/aquarium.py
+++ b/aquarium.py
@@ -302,22 +302,22 @@ def deploy(
                 f.write(f'alias stk{i}d="{test_framework.revaultd.REVAULTD_PATH} --conf {stk.conf_file}"\n')
                 if WITH_GUI:
                     f.write(
-                        f"alias stk{i}gui='{revault_gui} --conf {stk.gui_conf_file}'\n"
+                        f"alias stk{i}gui='{revault_gui} --conf {stk.gui_conf_file} > /dev/null'\n"
                     )
                     if WITH_ALL_HWS:
                         f.write(
-                            f"alias stk{i}hw='{dummysigner} {stk.stk_keychain.hd.get_xpriv()}'\n"
+                            f"alias stk{i}hw='{dummysigner} {stk.stk_keychain.hd.get_xpriv()} > /dev/null'\n"
                         )
             for i, man in enumerate(rn.man_wallets):
                 f.write(f'alias man{i}cli="{revault_cli} --conf {man.conf_file}"\n')
                 f.write(f'alias man{i}d="{test_framework.revaultd.REVAULTD_PATH} --conf {man.conf_file}"\n')
                 if WITH_GUI:
                     f.write(
-                        f"alias man{i}gui='{revault_gui} --conf {man.gui_conf_file}'\n"
+                        f"alias man{i}gui='{revault_gui} --conf {man.gui_conf_file} > /dev/null'\n"
                     )
                     if WITH_ALL_HWS:
                         f.write(
-                            f"alias man{i}hw='{dummysigner} {man.man_keychain.hd.get_xpriv()}'\n"
+                            f"alias man{i}hw='{dummysigner} {man.man_keychain.hd.get_xpriv()} > /dev/null'\n"
                         )
             for i, stkman in enumerate(rn.stkman_wallets):
                 f.write(
@@ -328,18 +328,18 @@ def deploy(
                 )
                 if WITH_GUI:
                     f.write(
-                        f"alias stkman{i}gui='{revault_gui} --conf {stkman.gui_conf_file}'\n"
+                        f"alias stkman{i}gui='{revault_gui} --conf {stkman.gui_conf_file} > /dev/null'\n"
                     )
                     if WITH_ALL_HWS:
                         f.write(
-                            f"alias stkman{i}hwstk='{dummysigner} {stkman.stk_keychain.hd.get_xpriv()}'\n"
+                            f"alias stkman{i}hwstk='{dummysigner} {stkman.stk_keychain.hd.get_xpriv()} > /dev/null'\n"
                         )
                         f.write(
-                            f"alias stkman{i}hwman='{dummysigner} {stkman.man_keychain.hd.get_xpriv()}'\n"
+                            f"alias stkman{i}hwman='{dummysigner} {stkman.man_keychain.hd.get_xpriv()} > /dev/null'\n"
                         )
             # hw for all the keys.
             if WITH_GUI:
-                f.write(f"alias hw='{dummysigner} --conf {dummysigner_conf_file}'\n")
+                f.write(f"alias hw='{dummysigner} --conf {dummysigner_conf_file} > /dev/null'\n")
 
         with open(aliases_file, "r") as f:
             available_aliases = "".join(f.readlines()[1:])


### PR DESCRIPTION
For easy use at start up, we dump
the logs from gui and hw.

The daemon aliases does not have > /dev/null
append to it because it is likely unused by the user
and if used, it is to detect error at start up and
requires the logs.

close #40